### PR TITLE
fix(server): include Eurolm.Driver in solution restore

### DIFF
--- a/server/Blocks.slnx
+++ b/server/Blocks.slnx
@@ -1,9 +1,7 @@
 <Solution>
   <Project Path="Api/Api.csproj" />
   <Project Path="Eurolm.DomainService/Eurolm.DomainService.csproj" />
-  <Project Path="Eurolm.Driver/Eurolm.Driver.csproj">
-    <Build Solution="Debug|*" Project="false" />
-  </Project>
+  <Project Path="Eurolm.Driver/Eurolm.Driver.csproj" />
   <Project Path="Worker/Worker.csproj" />
   <Project Path="XUnitTest/XUnitTest.csproj" />
 </Solution>


### PR DESCRIPTION
`dotnet restore Blocks.slnx` skipped `Eurolm.Driver` because the project was excluded from the build in the `Debug` solution configuration. The shared SonarQube workflow then runs `dotnet build --no-restore --configuration Release`, which does include the project, so it failed with:

```
error NETSDK1004: Assets file 'server/Eurolm.Driver/obj/project.assets.json' not found.
```

Surfaced on dev once `RUN_SONARQUBE`/`RUN_TESTS`/`RUN_SCA_SCAN` were flipped to `true` in 41d8bad — the shared workflow had never run on this repo before.

Verified the cause: after `dotnet restore Blocks.slnx`, every project had `obj/project.assets.json` except `Eurolm.Driver`.

Removing the `<Build Solution="Debug|*" Project="false" />` exclusion makes restore cover the project in all configurations. It compiles cleanly in Release (the inception pipeline already builds it that way).