### PR TITLE
Cover the upload, filter, clipboard and export history branches

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -219,3 +219,8 @@ scripts/scan.sh
 
 # local scan and coverage output, never committed
 results/
+
+# --- AI agent instruction files (do not commit) ---
+QWEN.md
+.clinerules
+.windsurfrules

--- a/.gitignore
+++ b/.gitignore
@@ -216,3 +216,6 @@ copilot-instructions.md
 !SECURITY.md
 !CODE_OF_CONDUCT.md
 scripts/scan.sh
+
+# local scan and coverage output, never committed
+results/

--- a/client/app/cross-modules/localization/components/import-language-file/import-file-modal.test.tsx
+++ b/client/app/cross-modules/localization/components/import-language-file/import-file-modal.test.tsx
@@ -501,4 +501,68 @@ describe("components/import-file-modal", () => {
     fireEvent.click(screen.getByText("remove item 0"));
     await waitFor(() => expect(screen.queryByText("data.json")).toBeNull());
   });
+
+  // The upload catch normalises whatever was thrown into something the toast can
+  // render. Each shape below takes a different branch of that fallback chain, and
+  // the last one is the guard against surfacing nothing useful to the user.
+  describe("upload error messages", () => {
+    const uploadAndCatch = async (thrown: unknown) => {
+      presign.mockRejectedValue(thrown);
+      renderModal();
+      dropFile(
+        makeFile("data.json", JSON.stringify([{ KeyName: "greeting" }]), "application/json"),
+      );
+      await screen.findByText("data.json");
+      fireEvent.click(screen.getByRole("button", { name: "Upload" }));
+      await waitFor(() => expect(showErrorToast).toHaveBeenCalled());
+      return vi.mocked(showErrorToast).mock.calls.at(-1)?.[0];
+    };
+
+    it("joins an errors array carried on the thrown value", async () => {
+      expect(await uploadAndCatch({ errors: ["too big", "wrong type"] })).toEqual({
+        errors: "too big, wrong type",
+      });
+    });
+
+    it("passes through a field keyed errors object", async () => {
+      // isErrorWithErrors only matches when errors is itself an object, so a
+      // validation map reaches the toast unflattened.
+      const errors = { keyName: ["is required"] };
+      expect(await uploadAndCatch({ errors })).toEqual({ errors });
+    });
+
+    it("keeps the whole value when errors is a bare string", async () => {
+      // A string errors field fails the isErrorWithErrors guard, so this lands in
+      // the generic object branch rather than being unwrapped.
+      const thrown = { errors: "single failure" };
+      expect(await uploadAndCatch(thrown)).toEqual({ errors: thrown });
+    });
+
+    it("uses the message of a thrown Error", async () => {
+      expect(await uploadAndCatch(new Error("network down"))).toEqual({
+        errors: "network down",
+      });
+    });
+
+    it("joins a thrown array", async () => {
+      expect(await uploadAndCatch(["first", "second"])).toEqual({
+        errors: "first, second",
+      });
+    });
+
+    it("passes through a thrown string", async () => {
+      expect(await uploadAndCatch("plain failure")).toEqual({ errors: "plain failure" });
+    });
+
+    it("passes through a thrown object as is", async () => {
+      const thrown = { code: 500 };
+      expect(await uploadAndCatch(thrown)).toEqual({ errors: thrown });
+    });
+
+    it("falls back to a readable message when nothing usable was thrown", async () => {
+      expect(await uploadAndCatch(null)).toEqual({
+        errors: "An unexpected error occurred during upload. Please try again.",
+      });
+    });
+  });
 });

--- a/client/app/cross-modules/localization/components/language-table-toolbar/language-table-toolbar.filters.test.tsx
+++ b/client/app/cross-modules/localization/components/language-table-toolbar/language-table-toolbar.filters.test.tsx
@@ -1,0 +1,131 @@
+import { fireEvent, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { renderWithProviders } from "@/test-utils/render";
+
+// The two date branches and the generic fallback are only reachable through
+// FilterToolbar's onChange. Stub the toolbar so each case can hand over an exact
+// value, and keep the real useSortQueryParams the module also re-exports. This is a
+// separate file because the sibling tests render the real toolbar.
+vi.mock("@/components/filter-toolbar", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/components/filter-toolbar")>();
+  return {
+    ...actual,
+    FilterToolbar: ({
+      onChange,
+      onReset,
+    }: {
+      onChange: (key: string, value: unknown) => void;
+      onReset: () => void;
+    }) => (
+      <div>
+        <button
+          onClick={() =>
+            onChange("createDate", {
+              from: new Date("2026-01-15T00:00:00.000Z"),
+              to: new Date("2026-01-20T00:00:00.000Z"),
+            })
+          }
+        >
+          set-create
+        </button>
+        <button onClick={() => onChange("createDate", null)}>clear-create</button>
+        <button
+          onClick={() =>
+            onChange("lastUpdateDate", {
+              from: new Date("2026-02-01T00:00:00.000Z"),
+              to: new Date("2026-02-05T00:00:00.000Z"),
+            })
+          }
+        >
+          set-updated
+        </button>
+        <button onClick={() => onChange("lastUpdateDate", null)}>clear-updated</button>
+        <button onClick={() => onChange("moduleIds", ["m1", "m2"])}>set-modules</button>
+        <button onClick={onReset}>do-reset</button>
+      </div>
+    ),
+  };
+});
+
+import {
+  LanguageTableToolbar,
+  useKeysFilterQueryParams,
+} from "./language-table-toolbar";
+
+const Probe = () => {
+  const { queryParams } = useKeysFilterQueryParams();
+  return <pre data-testid="params">{JSON.stringify(queryParams)}</pre>;
+};
+
+const params = () => JSON.parse(screen.getByTestId("params").textContent || "{}");
+
+const renderToolbar = (searchParams = "") =>
+  renderWithProviders(
+    <>
+      <LanguageTableToolbar languageModulesData={[]} languagesData={[]} />
+      <Probe />
+    </>,
+    { searchParams },
+  );
+
+describe("components/language-table-toolbar filters", () => {
+  it("stores a created range as ISO strings", () => {
+    renderToolbar();
+
+    fireEvent.click(screen.getByText("set-create"));
+
+    expect(params()).toMatchObject({
+      createStartDate: "2026-01-15T00:00:00.000Z",
+      createEndDate: "2026-01-20T00:00:00.000Z",
+      pageNumber: 0,
+    });
+  });
+
+  it("clears the created range when it is removed", () => {
+    renderToolbar("?createStartDate=2026-01-15T00:00:00.000Z");
+
+    fireEvent.click(screen.getByText("clear-create"));
+
+    expect(params()).toMatchObject({ createStartDate: "", createEndDate: "" });
+  });
+
+  it("stores a last updated range as ISO strings", () => {
+    renderToolbar();
+
+    fireEvent.click(screen.getByText("set-updated"));
+
+    expect(params()).toMatchObject({
+      lastUpdateStartDate: "2026-02-01T00:00:00.000Z",
+      lastUpdateEndDate: "2026-02-05T00:00:00.000Z",
+    });
+  });
+
+  it("clears the last updated range when it is removed", () => {
+    renderToolbar("?lastUpdateStartDate=2026-02-01T00:00:00.000Z");
+
+    fireEvent.click(screen.getByText("clear-updated"));
+
+    expect(params()).toMatchObject({ lastUpdateStartDate: "", lastUpdateEndDate: "" });
+  });
+
+  it("passes any other filter straight through and returns to the first page", () => {
+    renderToolbar("?pageNumber=4");
+
+    fireEvent.click(screen.getByText("set-modules"));
+
+    expect(params()).toMatchObject({ moduleIds: ["m1", "m2"], pageNumber: 0 });
+  });
+
+  it("returns every filter to its default on reset", () => {
+    renderToolbar("?moduleIds=m1&pageNumber=3&createStartDate=2026-01-15T00:00:00.000Z");
+
+    fireEvent.click(screen.getByText("do-reset"));
+
+    expect(params()).toMatchObject({
+      moduleIds: [],
+      pageNumber: 0,
+      createStartDate: "",
+    });
+  });
+});

--- a/client/app/cross-modules/localization/language-module/export-history/export-history-filters.date-range.test.tsx
+++ b/client/app/cross-modules/localization/language-module/export-history/export-history-filters.date-range.test.tsx
@@ -1,0 +1,108 @@
+import { fireEvent, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { renderWithProviders } from "@/test-utils/render";
+
+// The date-range branch is reached through FilterToolbar's onChange, and driving a
+// real calendar widget would test the picker rather than the conversion logic here.
+// Stub the toolbar so each case can hand the component an exact from/to pair. This
+// lives in its own file because the sibling tests exercise the real toolbar.
+vi.mock("@/components/filter-toolbar", () => ({
+  FilterToolbar: ({
+    onChange,
+  }: {
+    onChange: (key: string, value: unknown) => void;
+  }) => (
+    <div>
+      <button onClick={() => onChange("created", { from: new Date(2026, 0, 15) })}>from-only</button>
+      <button
+        onClick={() =>
+          onChange("created", { from: new Date(2026, 0, 15), to: new Date(2026, 0, 20) })
+        }
+      >
+        different-days
+      </button>
+      <button
+        onClick={() =>
+          onChange("created", { from: new Date(2026, 0, 15), to: new Date(2026, 0, 15) })
+        }
+      >
+        same-day
+      </button>
+      <button onClick={() => onChange("created", null)}>cleared</button>
+    </div>
+  ),
+}));
+
+import { ExportHistoryFilters } from "./export-history-filters";
+
+describe("language-module/export-history-filters date range", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("sends the start date and leaves the end date empty when only a start is picked", () => {
+    const onChange = vi.fn();
+    renderWithProviders(<ExportHistoryFilters onChange={onChange} />);
+
+    fireEvent.click(screen.getByText("from-only"));
+
+    expect(onChange).toHaveBeenCalledWith(
+      expect.objectContaining({
+        startDate: "2026-01-15T00:00:00.000Z",
+        endDate: "",
+        pageNumber: 0,
+      }),
+    );
+  });
+
+  it("sends both dates when the range spans different days", () => {
+    const onChange = vi.fn();
+    renderWithProviders(<ExportHistoryFilters onChange={onChange} />);
+
+    fireEvent.click(screen.getByText("different-days"));
+
+    expect(onChange).toHaveBeenCalledWith(
+      expect.objectContaining({
+        startDate: "2026-01-15T00:00:00.000Z",
+        endDate: "2026-01-20T00:00:00.000Z",
+      }),
+    );
+  });
+
+  it("drops the end date when the range starts and ends on the same day", () => {
+    // A single-day pick would otherwise send an end date equal to the start, which
+    // the history query treats as a two-sided range.
+    const onChange = vi.fn();
+    renderWithProviders(<ExportHistoryFilters onChange={onChange} />);
+
+    fireEvent.click(screen.getByText("same-day"));
+
+    expect(onChange).toHaveBeenCalledWith(
+      expect.objectContaining({
+        startDate: "2026-01-15T00:00:00.000Z",
+        endDate: "",
+      }),
+    );
+  });
+
+  it("clears both dates when the range is removed", () => {
+    const onChange = vi.fn();
+    renderWithProviders(<ExportHistoryFilters onChange={onChange} />);
+
+    fireEvent.click(screen.getByText("cleared"));
+
+    expect(onChange).toHaveBeenCalledWith(
+      expect.objectContaining({ startDate: "", endDate: "" }),
+    );
+  });
+
+  it("formats month and day with a leading zero", () => {
+    // Guards the padStart calls: a naive template would emit 2026-1-5.
+    const onChange = vi.fn();
+    renderWithProviders(<ExportHistoryFilters onChange={onChange} />);
+
+    fireEvent.click(screen.getByText("from-only"));
+
+    const [call] = onChange.mock.calls;
+    expect(call[0].startDate).toMatch(/^\d{4}-\d{2}-\d{2}T00:00:00\.000Z$/);
+  });
+});

--- a/client/app/cross-modules/localization/language-module/extension-guides/extension-guides.test.tsx
+++ b/client/app/cross-modules/localization/language-module/extension-guides/extension-guides.test.tsx
@@ -59,3 +59,94 @@ describe("ExtensionGuides", () => {
     );
   });
 });
+
+describe("ExtensionGuides copy to clipboard", () => {
+  const originalClipboard = Object.getOwnPropertyDescriptor(navigator, "clipboard");
+
+  beforeEach(() => {
+    getRuntimeEnvMock.mockImplementation((key: string) => {
+      if (key === "BLOCKS_PUBLIC_API_BASE_URL") return "https://runtime-api.example.com";
+      if (key === "BLOCKS_X_BLOCKS_KEY") return "runtime-blocks-key";
+      if (key === "BLOCKS_LOCALIZATION_BASE_URL") return "https://localization.example.com/";
+      return "";
+    });
+  });
+
+  afterEach(() => {
+    if (originalClipboard) {
+      Object.defineProperty(navigator, "clipboard", originalClipboard);
+    }
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  const copyButton = (label: string) => screen.getByRole("button", { name: `Copy ${label}` });
+
+  it("writes the value with the clipboard api and marks the field copied", async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    setClipboard({ writeText });
+    render(<ExtensionGuides />);
+
+    fireEvent.click(copyButton("API Base URL"));
+
+    await waitFor(() => expect(screen.getByText("Copied")).toBeTruthy());
+    expect(writeText).toHaveBeenCalledWith("https://runtime-api.example.com");
+  });
+
+  it("clears the copied marker after the two second timeout", async () => {
+    vi.useFakeTimers();
+    try {
+      const writeText = vi.fn().mockResolvedValue(undefined);
+      setClipboard({ writeText });
+      render(<ExtensionGuides />);
+
+      fireEvent.click(copyButton("X-Blocks-Key"));
+      // let the awaited writeText settle before the timer is asserted
+      await act(async () => {});
+      expect(screen.getByText("Copied")).toBeTruthy();
+
+      await act(async () => {
+        vi.advanceTimersByTime(2000);
+      });
+
+      expect(screen.queryByText("Copied")).toBeNull();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("falls back to execCommand when the clipboard api is unavailable", async () => {
+    setClipboard(undefined);
+    const execCommand = vi.fn().mockReturnValue(true);
+    document.execCommand = execCommand as unknown as typeof document.execCommand;
+    render(<ExtensionGuides />);
+
+    fireEvent.click(copyButton("API Base URL"));
+
+    await waitFor(() => expect(screen.getByText("Copied")).toBeTruthy());
+    expect(execCommand).toHaveBeenCalledWith("copy");
+    // the temporary textarea must not be left behind in the document
+    expect(document.querySelector("textarea")).toBeNull();
+  });
+
+  it("leaves the field unmarked when the fallback copy command fails", async () => {
+    setClipboard(undefined);
+    document.execCommand = vi.fn().mockReturnValue(false) as unknown as typeof document.execCommand;
+    render(<ExtensionGuides />);
+
+    fireEvent.click(copyButton("API Base URL"));
+
+    await waitFor(() => expect(document.querySelector("textarea")).toBeNull());
+    expect(screen.queryByText("Copied")).toBeNull();
+  });
+
+  it("leaves the field unmarked when the clipboard api rejects", async () => {
+    setClipboard({ writeText: vi.fn().mockRejectedValue(new Error("denied")) });
+    render(<ExtensionGuides />);
+
+    fireEvent.click(copyButton("API Base URL"));
+
+    await act(async () => {});
+    expect(screen.queryByText("Copied")).toBeNull();
+  });
+});

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -6642,9 +6642,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "dev": true,
       "funding": [
         {

--- a/e2e/package-lock.json
+++ b/e2e/package-lock.json
@@ -1298,9 +1298,9 @@
       "license": "ISC"
     },
     "node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "dev": true,
       "funding": [
         {
@@ -1821,6 +1821,21 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
       }
     },
     "node_modules/undici-types": {


### PR DESCRIPTION
Brings `inception` up to `dev` for blocks-localization.

## Commits
- test(fe): cover the upload error normalisation branches
- test(fe): cover the language table filter and reset handlers
- test(fe): cover clipboard copying and the export history date range
- chore: ignore local scan and coverage output
- fix(deps): bump js-yaml and brace-expansion to patched versions

## Verification
- Frontend unit tests: 929 passed across 79 files (`vitest run`).
- gitleaks and trufflehog run locally before pushing. No verified secrets, and no findings introduced by these commits.
